### PR TITLE
Add support for doing deep merge on two structs

### DIFF
--- a/lib/kitchensink/misc.ex
+++ b/lib/kitchensink/misc.ex
@@ -15,7 +15,11 @@ defmodule KitchenSink.Misc do
       tuple when is_tuple(tuple) ->
         elem(tuple, index)
       map when is_map(map) ->
-        map |> Stream.take(index + 1) |> Stream.drop(index) |> Enum.to_list |> Map.new
+        map
+        |> Stream.take(index + 1)
+        |> Stream.drop(index)
+        |> Enum.to_list
+        |> Map.new
     end
   end
 

--- a/test/kitchensink_test/map_test.exs
+++ b/test/kitchensink_test/map_test.exs
@@ -80,4 +80,24 @@ defmodule KitchenSink.MapTest do
     assert Map.rename_key(%{a: 1}, %{a: :b}) == %{b: 1}
     assert Map.rename_key(%{a: 1}, [a: :b]) == %{b: 1}
   end
+
+  defmodule TestMap do
+    defstruct name: nil,
+              age: 0
+  end
+
+  test "Clean struct" do
+    user1 = %TestMap{name: "User 1"}
+    expected = %{name: "User 1"}
+    actual = Map.clean_struct(user1)
+    assert actual == expected
+  end
+
+  test "Don't overwrite structs when default" do
+    user1 = %TestMap{name: "User 1"}
+    user2 = %TestMap{age: 21}
+    expected = %TestMap{name: "User 1", age: 21}
+    actual = Map.deep_merge(user1, user2)
+    assert actual == expected
+  end
 end


### PR DESCRIPTION
since structs have default values so if you want to do partial merges with structs you have a problem with the default values that would overwrite all the values in the other struct.
