### PR TITLE
Add support for optional key in transformation map for Map.transform

### DIFF
--- a/lib/kitchen_sink/map.ex
+++ b/lib/kitchen_sink/map.ex
@@ -262,10 +262,11 @@ defmodule KitchenSink.Map do
   """
   @lint {Credo.Check.Refactor.ABCSize, false}
   @spec transform(Map.t, Map.t, Keyword.t) :: Map.t
-  def transform(map, key_value_transform_map, [prune: true] = _opts) do
+  def transform(map, transformation_map, [prune: true] = _opts) do
     transform_key_value = fn (map, key, transform_fun) ->
       Map.get(map, key) |> transform_fun.()
     end
+
     renamed_key = fn(map) ->
       fn
         # only transform values
@@ -288,7 +289,13 @@ defmodule KitchenSink.Map do
       end
     end
 
-    key_value_transform_map
+    t_map_keys = Map.keys(transformation_map)
+    input_map_keys = Map.keys(map)
+    # you can do t_map_keys -- input_map_keys here, but this is faster for large maps.
+    keys_to_drop = MapSet.difference(MapSet.new(t_map_keys), MapSet.new(input_map_keys))
+    cleaned_t_map = Map.drop(transformation_map, keys_to_drop)
+
+    cleaned_t_map
     |> Enum.map(renamed_key.(map))
     |> deep_merge
   end
@@ -308,12 +315,12 @@ defmodule KitchenSink.Map do
   output.
   """
   @spec transform(Map.t, Map.t) :: Map.t
-  def transform(map, key_value_transform_map) do
-    keys_to_transform = Map.keys(key_value_transform_map)
+  def transform(map, transformation_map) do
+    keys_to_transform = Map.keys(transformation_map)
     map_without_transformed_keys = map |> Map.drop(keys_to_transform)
 
     map
-    |> transform(key_value_transform_map, prune: true)
+    |> transform(transformation_map, prune: true)
     |> deep_merge(map_without_transformed_keys)
   end
 
@@ -329,9 +336,9 @@ defmodule KitchenSink.Map do
   transformers in the transformer-map to the corresponding keys and values in the Map, outputing a Map where each
   key-value in the Map has been transformed.
   """
-  def transform(key_value_transform_map) do
+  def transform(transformation_map) do
     fn map ->
-      transform(map, key_value_transform_map)
+      transform(map, transformation_map)
     end
   end
 

--- a/test/kitchen_sink/map/transform_test.exs
+++ b/test/kitchen_sink/map/transform_test.exs
@@ -1,0 +1,68 @@
+defmodule KitchenSink.MapTest.TransformTest do
+  @moduledoc false
+
+  use ExUnit.Case
+  alias KitchenSink.Map, as: KMap
+
+  setup do
+    %{
+      expected: %{
+        new_age: 32,
+        gender: :Female,
+        rate: %{inner_rate: 28.71},
+        smoker!: :Smoker,
+        term: 75
+      },
+
+      input: %{
+        age: 32,
+        gender: "Female",
+        multiplier: "28.71",
+        smoker?: "Smoker",
+        term: "75.0"
+      },
+
+      t_map: %{
+        age: {[:new_age], fn x -> x end},
+        gender: {:gender, &String.to_atom/1},
+        multiplier: {[:rate, :inner_rate],&String.to_float/1},
+        smoker?: {:smoker! ,&String.to_atom/1},
+        term: {&String.to_float/1},
+      }
+    }
+  end
+
+  test "transform/1 returns a tranformation function", %{ expected: expected, input: input, t_map: t_map } do
+    actual = KMap.transform(t_map).(input)
+    assert actual == expected
+  end
+
+  test "transform/2 transform input using t_map", %{ expected: expected, input: input, t_map: t_map } do
+    actual = KMap.transform(input, t_map)
+    assert actual == expected
+  end
+
+  test "transform/3 :prune option prunes keys not defined in tranform",
+    %{ expected: expected, input: input, t_map: t_map } do
+    fat_input = Map.put_new(input, :a, :a)
+    actual = KMap.transform(fat_input, t_map, prune: true)
+
+    assert actual == expected
+  end
+
+  test "transform/3 does not prunes keys by default", %{ expected: expected, input: input, t_map: t_map } do
+    input = Map.put_new(input, :abc, 123)
+    expected = Map.put_new(expected, :abc, 123)
+    actual = KMap.transform(input, t_map)
+
+    assert actual == expected
+  end
+
+  test "transform/3 allows transform_map to have more keys than input",
+    %{ expected: expected, input: input, t_map: t_map } do
+    t_map = Map.put_new(t_map, :abc, {fn t -> t end})
+    actual = KMap.transform(input, t_map)
+
+    assert actual == expected
+  end
+end

--- a/test/kitchen_sink/map_test.exs
+++ b/test/kitchen_sink/map_test.exs
@@ -163,47 +163,6 @@ defmodule KitchenSink.MapTest do
   end
 
 
-  test "transform" do
-
-    expected = %{
-      new_age: 32,
-      gender: :Female,
-      rate: %{inner_rate: 28.71},
-      smoker!: :Smoker,
-      term: 75}
-
-    input = %{
-      age: 32,
-      gender: "Female",
-      multiplier: "28.71",
-      smoker?: "Smoker",
-      term: "75.0"}
-
-    transformation_map = %{
-      age: {[:new_age], fn x -> x end},
-      gender: {:gender, &String.to_atom/1},
-      multiplier: {[:rate, :inner_rate],&String.to_float/1},
-      smoker?: {:smoker! ,&String.to_atom/1},
-      term: {&String.to_float/1},
-    }
-
-    fat_input = Map.put_new(input, :a, :a)
-    actual = KMap.transform(fat_input, transformation_map, prune: true)
-    assert actual == expected
-
-    actual = KMap.transform(input, transformation_map)
-    assert actual == expected
-
-    actual = KMap.transform(transformation_map).(input)
-    assert actual == expected
-
-    #testing unprocessed values are preserved
-    input = Map.put_new(input, :abc, 123)
-    expected = Map.put_new(expected, :abc, 123)
-    actual = KMap.transform(input, transformation_map)
-    assert actual == expected
-  end
-
   test "key paths" do
 
     input = %{a: 1, c: 2, d: 3}


### PR DESCRIPTION
Previously, transformation maps for `Map.transform` would not accept a
map with more keys than the input. This is suboptimal because we might
want to apply the same transformation to inputs of various sizes (but
with common structure). This commit adds support for that.