### PR TITLE
Don't pollute structs when trying to merge invalid keys

### DIFF
--- a/lib/kitchen_sink/map.ex
+++ b/lib/kitchen_sink/map.ex
@@ -57,6 +57,15 @@ defmodule KitchenSink.Map do
     do_deep_merge(left, right)
   end
 
+  defp do_deep_merge(%{__struct__: _} = left, right) do
+    :maps.map(fn key, left_value ->
+      case Map.get(right, key) do
+        nil         -> left_value
+        right_value -> do_deep_resolve(key, left_value, right_value)
+      end
+    end, left)
+  end
+
   defp do_deep_merge(left, right) do
     Map.merge(left, right, &do_deep_resolve/3)
   end

--- a/test/kitchen_sink/map_test.exs
+++ b/test/kitchen_sink/map_test.exs
@@ -152,6 +152,17 @@ defmodule KitchenSink.MapTest do
     assert actual == expected
   end
 
+  test "Don't pollute structs when trying to merge invalid keys" do
+    user1 = %TestMap{name: "User 1"}
+    user2 = %{
+      name: "John Appleseed",
+      address: "1 Infinite Loop, Cupertino, CA 95014, USA"
+    }
+    expected = %TestMap{name: "John Appleseed"}
+    actual = KMap.deep_merge(user1, user2)
+    assert actual == expected
+  end
+
   test "transform_values" do
 
     expected = %{age: 32, gender: :Female, multiplier: 28.71 , smoker?: :Smoker, term: 75}


### PR DESCRIPTION
As part of [ch1263](https://app.clubhouse.io/planswell/story/1263/clean-up-year-1-values), we want to ensure we can't merge invalid keys into a struct.

Paired on this with @olafura, so @kenips & @boxxxie please have a 👀 .