### PR TITLE
Add KitchenSink.Algorithms.binary_search & tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# KitchenSink 1.1.0 Release Notes (2017-06-13)
+
+## Changes since 1.0.2
+
+  * Added CHANGELOG.md
+  * Added KitchenSink.Algorithms
+    * binary_search/{2,3,4}
+  * Updated credo 0.6.1 → 0.8.1
+  * Updated dialyxir 0.4.4 → 0.5.0
+  * Updated ex_doc 0.14.5 → 0.16.1

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
     ```elixir
     def deps do
-      [{:kitchen_sink, "~> 1.0.2"}]
+      [{:kitchen_sink, "~> 1.1.0"}]
     end
     ```
 

--- a/lib/kitchen_sink/algorithms.ex
+++ b/lib/kitchen_sink/algorithms.ex
@@ -10,97 +10,110 @@ defmodule KitchenSink.Algorithms do
   lower.
   """
 
-  @type fit_func :: (number -> :ok | :high | :low)
-  @type mid_func :: (number, number -> number)
-  @type binary_search_result :: {:ok, number} | :not_found
+  @type binary_search_position :: integer
+  @type binary_search_fit_func :: (binary_search_position, any -> :ok | :high | :low)
+  @type binary_search_mid_func :: (binary_search_position, binary_search_position -> binary_search_position)
+  @type binary_search_result :: {:ok, binary_search_position} | :not_found
+
+  @type binary_interval_search_position :: number
+  @type binary_interval_search_fit_func :: (binary_interval_search_position, any -> :ok | :high | :low)
+  @type binary_interval_search_result :: {:ok, binary_interval_search_position} | :not_found
 
   @doc """
-  `binary_search` performs a binary search over a `Range`. The
-  range's start should be less than or equal to the finish, if not
-  then they are swapped.
+  `binary_search` performs a binary search over a range.
 
   ## Examples
 
-      iex> look_for = fn(desired_result) ->
-      ...>   fn(value_to_test) ->
-      ...>     cond do
-      ...>       value_to_test < desired_result -> :high
-      ...>       value_to_test == desired_result -> :ok
-      ...>       value_to_test > desired_result -> :low
-      ...>     end
+      iex> names = ~w(Adrian Bill Robert Tony) # Sorted!
+      iex> search_names = fn(position, target) ->
+      ...>   current = Enum.at(names, position)
+      ...>   cond do
+      ...>     current < target -> :high
+      ...>     current == target -> :ok
+      ...>     current > target -> :low
       ...>   end
       ...> end
       iex>
-      iex> Algorithms.binary_search(1 .. 10, look_for.(7))
-      {:ok, 7}
-      iex> Algorithms.binary_search(1 .. 10, look_for.(17))
+      iex> Algorithms.binary_search(0, 3, search_names, "Tony")
+      {:ok, 3}
+      iex> Algorithms.binary_search(0, 3, search_names, "Phil")
       :not_found
-      iex> Algorithms.binary_search(1 .. 10, look_for.(7.5))
-      :not_found
+
+  It is *possible* to override the calculation of the midpoint for the binary
+  search, and that is "...left as an exercise for the reader."
   """
-  @spec binary_search(Range.t, fit_func) :: binary_search_result
-  def binary_search(start .. finish, fit) when finish < start, do: binary_search(finish .. start, fit)
-  def binary_search(%Range{} = range, fit), do: binary_search_range(range, fit)
-
-  @doc """
-  `binary_search` can also search in an interval. You must provide the start
-  and finish values and a `fit` function.
-
-  ## Examples
-
-      iex> look_for = fn(desired_result) ->
-      ...>   fn(value_to_test) ->
-      ...>     cond do
-      ...>       value_to_test < desired_result -> :high
-      ...>       value_to_test == desired_result -> :ok
-      ...>       value_to_test > desired_result -> :low
-      ...>     end
-      ...>   end
-      ...> end
-      iex>
-      iex> Algorithms.binary_search(1, 10, look_for.(7.5))
-      {:ok, 7.5}
-  """
-
-  @spec binary_search(number, number, fit_func) :: binary_search_result
-  def binary_search(start, finish, fit) when is_number(start) and is_number(finish) do
-    binary_search(start / 1, finish / 1, fit, &floating_mid/2)
+  @spec binary_search(
+    binary_search_position, binary_search_position, binary_search_fit_func, any, binary_search_mid_func
+  ) :: binary_search_result
+  def binary_search(range_start, range_finish, fit, target, calculate_mid \\ &binary_search_midpoint/2) when is_integer(range_start) and is_integer(range_finish) and is_function(fit) and is_function(calculate_mid) do
+    do_binary_search(range_start, range_finish, fit, target, calculate_mid)
   end
 
-  @doc """
-  You can provide a custom function for determining the mid point of a range
-  if the arithmetic mid-point does not meet your needs.
-  """
-  @spec binary_search(number, number, fit_func, mid_func) :: binary_search_result
-  def binary_search(start, finish, fit, calculate_mid) when finish < start do
-    binary_search(finish, start, fit, calculate_mid)
+  defp do_binary_search(start, finish, fit, target, calculate_mid) when finish < start do
+    binary_search(finish, start, fit, target, calculate_mid)
   end
-  def binary_search(x, x, fit, _), do: ok_or_not_found(x, fit)
-  def binary_search(start, finish, fit, calculate_mid) do
+  defp do_binary_search(position, position, fit, target, _), do: ok_or_not_found(position, fit, target)
+  defp do_binary_search(start, finish, fit, target, calculate_mid) do
     mid = calculate_mid.(start, finish)
-    case fit.(mid) do
+    case fit.(mid, target) do
       :ok -> {:ok, mid}
-      :high -> binary_search(mid, finish, fit, calculate_mid)
-      :low -> binary_search(start, mid, fit, calculate_mid)
+      :high -> do_binary_search((mid + 1), finish, fit, target, calculate_mid)
+      :low -> do_binary_search(start, (mid - 1), fit, target, calculate_mid)
     end
   end
 
-  defp binary_search_range(x .. x, fit), do: ok_or_not_found(x, fit)
-  defp binary_search_range(start .. finish, fit) do
-    mid = start + div(finish - start, 2)
-    case fit.(mid) do
+  defp binary_search_midpoint(start, finish) do
+    start + div(finish - start, 2)
+  end
+
+  @doc """
+  `binary_interval_search` can search in an interval.
+
+  ## Examples
+
+  To see where *y = 10 + x³* and *y = 1000 + x²* intersect
+
+      iex> solve = fn(position, _) ->
+      ...>   y1 = 10 + :math.pow(position, 3)
+      ...>   y2 = 1000 + :math.pow(position, 2)
+      ...>   difference = y1 - y2
+      ...>
+      ...>   epsilon = 0.0001
+      ...>
+      ...>   cond do
+      ...>     abs(difference) < epsilon -> :ok
+      ...>     difference > 0.0 -> :low
+      ...>     difference < 0.0 -> :high
+      ...>   end
+      ...> end
+      iex>
+      iex> {:ok, result} = Algorithms.binary_interval_search(1, 100, solve, 0.0)
+      iex> Float.round(result, 6)
+      10.311285
+  """
+
+  @spec binary_interval_search(
+    binary_interval_search_position, binary_interval_search_position, binary_interval_search_fit_func, any
+  ) :: binary_interval_search_result
+  def binary_interval_search(interval_start, interval_finish, fit, target \\ nil) when is_number(interval_start) and is_number(interval_finish) and is_function(fit) do
+    do_binary_interval_search(interval_start / 1, interval_finish / 1, fit, target)
+  end
+
+  defp do_binary_interval_search(position, position, fit, target), do: ok_or_not_found(position, fit, target)
+  defp do_binary_interval_search(start, finish, fit, target) when start > finish do
+    binary_interval_search(finish, start, fit, target)
+  end
+  defp do_binary_interval_search(start, finish, fit, target) do
+    mid = start + (finish - start) / 2.0
+    case fit.(mid, target) do
       :ok -> {:ok, mid}
-      :high -> binary_search_range((mid + 1) .. finish, fit)
-      :low -> binary_search_range(start .. (mid - 1), fit)
+      :high -> do_binary_interval_search(mid, finish, fit, target)
+      :low -> do_binary_interval_search(start, mid, fit, target)
     end
   end
 
-  defp floating_mid(range_start, range_finish) do
-    range_start + (range_finish - range_start) / 2
-  end
-
-  defp ok_or_not_found(n, fit) do
-    case fit.(n) do
+  defp ok_or_not_found(n, fit, target) do
+    case fit.(n, target) do
       :ok -> {:ok, n}
       _ -> :not_found
     end

--- a/lib/kitchen_sink/algorithms.ex
+++ b/lib/kitchen_sink/algorithms.ex
@@ -1,0 +1,108 @@
+defmodule KitchenSink.Algorithms do
+  @moduledoc """
+  This is a collection of algorithms.
+
+  ## The binary search `fit` function
+
+  The search is controlled by the `fit` function which is passed the value to
+  test and returns `:ok` if the value is good enough, `:high` if the next
+  value to test should be higher, or `:low` if the next value should be
+  lower.
+  """
+
+  @type fit_func :: (number -> :ok | :high | :low)
+  @type mid_func :: (number, number -> number)
+  @type binary_search_result :: {:ok, number} | :not_found
+
+  @doc """
+  `binary_search` performs a binary search over a `Range`. The
+  range's start should be less than or equal to the finish, if not
+  then they are swapped.
+
+  ## Examples
+
+      iex> look_for = fn(desired_result) ->
+      ...>   fn(value_to_test) ->
+      ...>     cond do
+      ...>       value_to_test < desired_result -> :high
+      ...>       value_to_test == desired_result -> :ok
+      ...>       value_to_test > desired_result -> :low
+      ...>     end
+      ...>   end
+      ...> end
+      iex>
+      iex> Algorithms.binary_search(1 .. 10, look_for.(7))
+      {:ok, 7}
+      iex> Algorithms.binary_search(1 .. 10, look_for.(17))
+      :not_found
+      iex> Algorithms.binary_search(1 .. 10, look_for.(7.5))
+      :not_found
+  """
+  @spec binary_search(Range.t, fit_func) :: binary_search_result
+  def binary_search(start .. finish, fit) when finish < start, do: binary_search(finish .. start, fit)
+  def binary_search(%Range{} = range, fit), do: binary_search_range(range, fit)
+
+  @doc """
+  `binary_search` can also search in an interval. You must provide the start
+  and finish values and a `fit` function.
+
+  ## Examples
+
+      iex> look_for = fn(desired_result) ->
+      ...>   fn(value_to_test) ->
+      ...>     cond do
+      ...>       value_to_test < desired_result -> :high
+      ...>       value_to_test == desired_result -> :ok
+      ...>       value_to_test > desired_result -> :low
+      ...>     end
+      ...>   end
+      ...> end
+      iex>
+      iex> Algorithms.binary_search(1, 10, look_for.(7.5))
+      {:ok, 7.5}
+  """
+
+  @spec binary_search(number, number, fit_func) :: binary_search_result
+  def binary_search(start, finish, fit) when is_number(start) and is_number(finish) do
+    binary_search(start / 1, finish / 1, fit, &floating_mid/2)
+  end
+
+  @doc """
+  You can provide a custom function for determining the mid point of a range
+  if the arithmetic mid-point does not meet your needs.
+  """
+  @spec binary_search(number, number, fit_func, mid_func) :: binary_search_result
+  def binary_search(start, finish, fit, calculate_mid) when finish < start do
+    binary_search(finish, start, fit, calculate_mid)
+  end
+  def binary_search(x, x, fit, _), do: ok_or_not_found(x, fit)
+  def binary_search(start, finish, fit, calculate_mid) do
+    mid = calculate_mid.(start, finish)
+    case fit.(mid) do
+      :ok -> {:ok, mid}
+      :high -> binary_search(mid, finish, fit, calculate_mid)
+      :low -> binary_search(start, mid, fit, calculate_mid)
+    end
+  end
+
+  defp binary_search_range(x .. x, fit), do: ok_or_not_found(x, fit)
+  defp binary_search_range(start .. finish, fit) do
+    mid = start + div(finish - start, 2)
+    case fit.(mid) do
+      :ok -> {:ok, mid}
+      :high -> binary_search_range((mid + 1) .. finish, fit)
+      :low -> binary_search_range(start .. (mid - 1), fit)
+    end
+  end
+
+  defp floating_mid(range_start, range_finish) do
+    range_start + (range_finish - range_start) / 2
+  end
+
+  defp ok_or_not_found(n, fit) do
+    case fit.(n) do
+      :ok -> {:ok, n}
+      _ -> :not_found
+    end
+  end
+end

--- a/lib/kitchen_sink/assert.ex
+++ b/lib/kitchen_sink/assert.ex
@@ -18,8 +18,6 @@ defmodule KitchenSink.Assert do
 
   Any nodes that fail this test will be displayed in nice colors in the assert error message.
   """
-  @lint {Credo.Check.Refactor.ABCSize, false}
-  _ = @lint # https://github.com/rrrene/credo/issues/291
   def assertish(expected, actual, epsilon, msg \\ "") when is_map(actual) and is_map(expected) do
     a_paths = KMap.key_paths(actual) |> Enum.sort
     e_paths = KMap.key_paths(expected) |> Enum.sort

--- a/lib/kitchen_sink/map.ex
+++ b/lib/kitchen_sink/map.ex
@@ -147,7 +147,7 @@ defmodule KitchenSink.Map do
   def rename_key(%{} = map, {current_key, new_key}) do
     rename_key(map, current_key, new_key)
   end
-  def rename_key(_,_) do
+  def rename_key(_, _) do
     %{}
   end
 
@@ -297,8 +297,6 @@ defmodule KitchenSink.Map do
   key-value in the Map has been transformed. supplying `prune: true` prunes the map so only transformed values are
   output.
   """
-  @lint {Credo.Check.Refactor.ABCSize, false}
-  _ = @lint # https://github.com/rrrene/credo/issues/291
   @spec transform(Map.t, Map.t, Keyword.t) :: Map.t
   def transform(map, transformation_map, [prune: true] = _opts) do
     transform_key_value = fn (map, key, transform_fun) ->
@@ -493,14 +491,11 @@ defmodule KitchenSink.Map do
 
   def is_enumerable(%{__struct__: module}), do: is_enumerable(module)
   def is_enumerable(type) when is_map(type), do: true
-  @lint {Credo.Check.Readability.PreferImplicitTry, false}
   def is_enumerable(type) do
-    try do
-      Protocol.assert_impl!(Enumerable, type)
-      true
-    rescue
-      ArgumentError -> false
-    end
+    Protocol.assert_impl!(Enumerable, type)
+    true
+  rescue
+    ArgumentError -> false
   end
 
   def do_trim(map, empty_val_fn?) do
@@ -535,7 +530,4 @@ defmodule KitchenSink.Map do
   def trim(%{} = map, empty_val_fn?) do
     do_trim(map, empty_val_fn?)
   end
-
-  # @lint workaround for Elixir 1.4.x
-  _ = @lint
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule KitchenSink.Mixfile do
 
   @moduledoc false
 
-  @version "1.0.2"
+  @version "1.1.0"
   @repo_url "https://github.com/planswell/kitchen-sink"
 
   def project do
@@ -22,13 +22,18 @@ defmodule KitchenSink.Mixfile do
       description: "Mixins for Elixir namespaces and Misc utility functions",
       # Docs
       name: "KitchenSink",
-      docs: [source_ref: "v#{@version}", main: "KitchenSink", source_url: @repo_url,  extras: ["README.md"]],
+      docs: [
+        source_ref: "v#{@version}",
+        main: "KitchenSink",
+        source_url: @repo_url,
+        extras: ["README.md", "CHANGELOG.md"],
+      ],
       elixirc_paths: elixirc_paths(Mix.env),
       dialyzer: [plt_add_deps: :transitive],
     ]
   end
 
-  defp elixirc_paths(:test), do: ["lib","test/support"]
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_),     do: ["lib"]
 
   def application do
@@ -47,9 +52,9 @@ defmodule KitchenSink.Mixfile do
 
   defp deps do
     [
-      {:credo, "~> 0.6.1", only: [:dev, :test]},
-      {:dialyxir, "~> 0.4.4", only: [:dev]},
-      {:ex_doc, "~> 0.14.5", only: :dev}
+      {:credo, "~> 0.8.1", only: [:dev, :test]},
+      {:dialyxir, "~> 0.5.0", only: [:dev], runtime: false},
+      {:ex_doc, "~> 0.16.1", only: :dev}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
-  "credo": {:hex, :credo, "0.6.1", "a941e2591bd2bd2055dc92b810c174650b40b8290459c89a835af9d59ac4a5f8", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
-  "dialyxir": {:hex, :dialyxir, "0.4.4", "e93ff4affc5f9e78b70dc7bec7b07da44ae1ed3fef38e7113568dd30ad7b01d3", [:mix], []},
-  "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]}}
+  "credo": {:hex, :credo, "0.8.1", "137efcc99b4bc507c958ba9b5dff70149e971250813cbe7d4537ec7e36997402", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, optional: false]}]},
+  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
+  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
+  "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}

--- a/test/kitchen_sink/algorithms_test.exs
+++ b/test/kitchen_sink/algorithms_test.exs
@@ -1,0 +1,34 @@
+defmodule KitchenSink.AlgorithmsTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  alias KitchenSink.Algorithms
+  doctest Algorithms
+
+  def look_for(desired_result) do
+    fn(value_to_test) ->
+      cond do
+        value_to_test < desired_result -> :high
+        value_to_test == desired_result -> :ok
+        value_to_test > desired_result -> :low
+      end
+    end
+  end
+
+  test "Range with reversed endpoints" do
+    assert {:ok, 3} == Algorithms.binary_search(5 .. 1, look_for(3))
+  end
+
+  test "Single element range with desired value" do
+    assert {:ok, 2} == Algorithms.binary_search(2 .. 2, look_for(2))
+  end
+
+  test "Single element range without desired value" do
+    assert :not_found == Algorithms.binary_search(2 .. 2, look_for(3))
+  end
+
+  test "Interval with reversed endpoints" do
+    assert {:ok, 3.5} == Algorithms.binary_search(5, 1, look_for(3.5))
+  end
+end

--- a/test/kitchen_sink/algorithms_test.exs
+++ b/test/kitchen_sink/algorithms_test.exs
@@ -6,29 +6,27 @@ defmodule KitchenSink.AlgorithmsTest do
   alias KitchenSink.Algorithms
   doctest Algorithms
 
-  def look_for(desired_result) do
-    fn(value_to_test) ->
-      cond do
-        value_to_test < desired_result -> :high
-        value_to_test == desired_result -> :ok
-        value_to_test > desired_result -> :low
-      end
+  def find_target(pos, desired_result) do
+    cond do
+      pos < desired_result -> :high
+      pos == desired_result -> :ok
+      pos > desired_result -> :low
     end
   end
 
   test "Range with reversed endpoints" do
-    assert {:ok, 3} == Algorithms.binary_search(5 .. 1, look_for(3))
+    assert {:ok, 3} == Algorithms.binary_search(5, 1, &find_target/2, 3)
   end
 
   test "Single element range with desired value" do
-    assert {:ok, 2} == Algorithms.binary_search(2 .. 2, look_for(2))
+    assert {:ok, 2} == Algorithms.binary_search(2, 2, &find_target/2, 2)
   end
 
   test "Single element range without desired value" do
-    assert :not_found == Algorithms.binary_search(2 .. 2, look_for(3))
+    assert :not_found == Algorithms.binary_search(2, 2, &find_target/2, 3)
   end
 
   test "Interval with reversed endpoints" do
-    assert {:ok, 3.5} == Algorithms.binary_search(5, 1, look_for(3.5))
+    assert {:ok, 3.5} == Algorithms.binary_interval_search(5, 1, &find_target/2, 3.5)
   end
 end


### PR DESCRIPTION
The ability to use a "special" calculation for mid point is for @maedhr .

## Changes since 1.0.2

  * Added CHANGELOG.md
  * Added KitchenSink.Algorithms
    * binary_search/{2,3,4}
  * Updated credo 0.6.1 → 0.8.1
  * Updated dialyxir 0.4.4 → 0.5.0
  * Updated ex_doc 0.14.5 → 0.16.1