### PR TITLE
Add typespec and doctests to Boolean, List, Math, and Misc

### DIFF
--- a/lib/kitchen_sink/boolean.ex
+++ b/lib/kitchen_sink/boolean.ex
@@ -18,15 +18,21 @@ defmodule KitchenSink.Boolean do
 
   @doc """
   Parse boolean either from string or integer, if it's not a boolean then it returns :error
+
+      iex> parse("True")
+      true
+      iex> parse("Lie")
+      :error
   """
-  def parse(st) when is_binary(st) do
-    st
+  @spec parse(String.t | integer) :: boolean | :error
+  def parse(value) when is_binary(value) do
+    value
     |> String.trim
     |> String.downcase
     |> string_bool?
   end
-  def parse(i) when is_integer(i) do
-    case i do
+  def parse(value) when is_integer(value) do
+    case value do
       1 -> true
       0 -> false
       _ -> :error

--- a/lib/kitchen_sink/list.ex
+++ b/lib/kitchen_sink/list.ex
@@ -5,12 +5,58 @@ defmodule KitchenSink.List do
 
   alias __MODULE__.IndexBy
 
+  @doc """
+  Creates an indexed list from a list of maps using a key_function or a path.
+  If a path is given then the `Access` module will be used.
+
+  This function is very similar to `group_by`, however the values will not be
+  grouped. There should be a 1-to-1 mapping for the key_fun to item in the list.
+  For different mapping ratio duplicate keys will be dropped, according to
+  `Map.new/1` logic
+
+  ## Examples
+
+      iex> [
+      ...>   %{name: :a, other: 1},
+      ...>   %{name: :b, other: 4}
+      ...> ] |> index_by(:name)
+      %{
+        a: %{name: :a, other: 1},
+        b: %{name: :b, other: 4}
+      }
+  """
   defdelegate index_by(list, path), to: IndexBy
 
   @doc """
-  takes a list of maps, transforms it into a map of maps with their value being the value_key. basically making a
-  look-up table.
+  Takes a list of maps, transforms it into a map of maps with their value being
+  the value_key. Basically making a look-up table.
+
+  ## Examples
+
+      iex> [
+      ...>   %{a: 1, b: "x"},
+      ...>   %{a: 2, b: "y"},
+      ...>   %{a: 3, b: "z"}
+      ...> ] |> index_on([:a], :b)
+      %{
+        %{a: 1} => "x",
+        %{a: 2} => "y",
+        %{a: 3} => "z"
+      }
+
+      iex> [
+      ...>   %{a: 1, b: "x"},
+      ...>   %{a: 2, b: "y"},
+      ...>   %{a: 3, b: "z"}
+      ...> ] |> index_on(:a, :b)
+      %{
+        %{a: 1} => "x",
+        %{a: 2} => "y",
+        %{a: 3} => "z"
+      }
+
   """
+  @spec index_on(list(map), list(any), any) :: map
   def index_on(list_of_maps, take_keys, value_key) do
     take_keys = take_keys |> List.wrap |> MapSet.new |> MapSet.delete(value_key)
     lookup_transform = fn(map) ->
@@ -26,10 +72,18 @@ defmodule KitchenSink.List do
   end
 
   @doc """
-  A convenient version of what is perhaps the most common use-case for map: extracting a list of property values.
+  A convenient version of what is perhaps the most common use-case for map:
+  extracting a list of property values.
 
   With a List of Maps, extract 1 value defined by the key you give to pluck.
+
+  ## Examples
+
+      iex> pluck([%{b: 1}, %{a: 2}, %{a: 3}], :a)
+      [nil, 2, 3]
+
   """
+  @spec pluck(list(map), any) :: list
   def pluck(list_of_maps, key) do
     Enum.map(list_of_maps, &Map.get(&1, key))
   end

--- a/lib/kitchen_sink/list/index_by.ex
+++ b/lib/kitchen_sink/list/index_by.ex
@@ -1,15 +1,7 @@
 defmodule KitchenSink.List.IndexBy do
   @moduledoc false
 
-  @doc """
-  creates and indexed list from a list of maps using a key_function or
-  a path. if a path is given then the access module will be used.
-
-  This function is very similar to group_by, however the values will
-  not be grouped. there should be a 1-to-1 mapping for the key_fun to
-  item in the list. if it's possible that you could have a different
-  mapping ratio, dupe keys will be dropped, according to Map.new logic
-  """
+  @spec index_by(list(map), function | atom | list(atom)) :: map
   def index_by(list, key_fun) when is_function(key_fun) do
     indices = Enum.map(list, key_fun)
     Enum.zip(indices, list) |> Map.new()

--- a/lib/kitchen_sink/math.ex
+++ b/lib/kitchen_sink/math.ex
@@ -4,11 +4,21 @@ defmodule KitchenSink.Math do
   Math functions!
   """
 
-  @doc """
-  handles divide by zero gracefully.
-
-  third argument is what to return when you divide by zero.
+  @typedoc """
+  Some functions allow us to specify *something* to return in a case which would
+  normally raise an error. This type identifies that.
   """
+  @type error_return :: any
+
+  @doc """
+  Numerical division which allows a specified return for "divide by zero."
+
+      iex> div(1, 2, :oops)
+      0.5
+      iex> div(1, 0, :oops)
+      :oops
+  """
+  @spec div(number, number, error_return) :: number | error_return
   def div(_numerator, 0, div_by_zero), do: div_by_zero
   def div(_numerator, 0.0, div_by_zero), do: div_by_zero
   def div(numerator, denominator, _div_by_zero), do: numerator / denominator
@@ -25,14 +35,15 @@ defmodule KitchenSink.Math do
     - significance: The multiple to which you would like to round.
                     Must not be 0.
 
-  ## Example:
+  ## Examples:
 
-  iex> round_down_to_multiple(31, 5)
-  30
+      iex> round_down_to_multiple(31, 5)
+      30
 
-  iex> round_down_to_multiple(29.49, 10)
-  20
+      iex> round_down_to_multiple(29.49, 10)
+      20
   """
+  @spec round_down_to_multiple(number, number) :: number | no_return
   def round_down_to_multiple(_, 0) do
     raise ArgumentError, message: "Significance multiple cannot be zero."
   end
@@ -49,14 +60,15 @@ defmodule KitchenSink.Math do
     - significance: The multiple to which you would like to round.
                     Must not be 0.
 
-  ## Example:
+  ## Examples:
 
-  iex> round_up_to_multiple(31, 5)
-  35
+      iex> round_up_to_multiple(31, 5)
+      35
 
-  iex> round_up_to_multiple(29.49, 10)
-  30
+      iex> round_up_to_multiple(29.49, 10)
+      30
   """
+  @spec round_up_to_multiple(number, number) :: number | no_return
   def round_up_to_multiple(_, 0) do
     raise ArgumentError, message: "Significance multiple cannot be zero."
   end

--- a/lib/kitchen_sink/misc.ex
+++ b/lib/kitchen_sink/misc.ex
@@ -5,9 +5,20 @@ defmodule KitchenSink.Misc do
   """
 
   @doc """
+  Return a function which returns the *n*th element (zero based) of a collection
+  which is passed to it.
 
+      iex> f = nth(2)
+      iex> f.(["a", "b", "c", "d", "e"])
+      "c"
+
+  Utility functions `first/1`, `second/1`, ... `tenth/1` are provided as
+  convenient short cuts. Be aware that `first/1` is really `nth(0)`.
+
+      iex> third(["a", "b", "c", "d", "e"])
+      "c"
   """
-
+  @spec nth(integer) :: (list | tuple | map -> any | no_return)
   def nth(index) do
     fn
       list when is_list(list) ->
@@ -23,15 +34,36 @@ defmodule KitchenSink.Misc do
     end
   end
 
+  @doc false
   def first(list), do: nth(0).(list)
-  def second(list), do: nth(1).(list)
-  def third(list), do: nth(2).(list)
-  def fourth(list), do: nth(3).(list)
-  def fifth(list), do: nth(4).(list)
-  def sixth(list), do: nth(5).(list)
-  def seventh(list), do: nth(6).(list)
-  def eighth(list), do: nth(7).(list)
-  def nineth(list), do: nth(8).(list)
-  def tenth(list), do: nth(9).(list)
 
+  @doc false
+  def second(list), do: nth(1).(list)
+
+  @doc false
+  def third(list), do: nth(2).(list)
+
+  @doc false
+  def fourth(list), do: nth(3).(list)
+
+  @doc false
+  def fifth(list), do: nth(4).(list)
+
+  @doc false
+  def sixth(list), do: nth(5).(list)
+
+  @doc false
+  def seventh(list), do: nth(6).(list)
+
+  @doc false
+  def eighth(list), do: nth(7).(list)
+
+  @doc false
+  def ninth(list), do: nth(8).(list)
+
+  @doc false
+  def nineth(list), do: nth(8).(list)
+
+  @doc false
+  def tenth(list), do: nth(9).(list)
 end

--- a/test/kitchen_sink/boolean_test.exs
+++ b/test/kitchen_sink/boolean_test.exs
@@ -4,7 +4,7 @@ defmodule KitchenSink.BooleanTest do
   use ExUnit.Case
   alias KitchenSink.Boolean
 
-  doctest KitchenSink.Boolean
+  doctest KitchenSink.Boolean, import: true
 
   test "boolean parse" do
     assert Boolean.parse("TRUE") === true

--- a/test/kitchen_sink/list_test.exs
+++ b/test/kitchen_sink/list_test.exs
@@ -4,24 +4,7 @@ defmodule KitchenSink.ListTest do
   use ExUnit.Case
   alias KitchenSink.List, as: L
 
-  doctest KitchenSink.List
-
-  test "index_on" do
-    expected = %{
-      %{a: 1} => 1,
-      %{a: 2} => 2,
-      %{a: 3} => 3
-    }
-
-    input = [
-      %{a: 1, b: 1},
-      %{a: 2, b: 2},
-      %{a: 3, b: 3}
-    ]
-
-    assert L.index_on(input, [:a], :b) == expected
-    assert L.index_on(input, :a, :b) == expected
-  end
+  doctest KitchenSink.List, import: true
 
   test "pluck" do
 
@@ -32,38 +15,11 @@ defmodule KitchenSink.ListTest do
 
     assert expected == actual
 
-
-    input = [%{b: 1}, %{a: 2}, %{a: 3}]
-    expected = [nil, 2, 3]
-
-    actual = L.pluck(input, :a)
-
-    assert expected == actual
-
-
     input = []
     expected = []
 
     actual = L.pluck(input, :a)
 
     assert expected == actual
-  end
-
-  describe "index_by/2" do
-    test "index by key"do
-      expected = %{
-        a: %{name: :a, other: 1},
-        b: %{name: :b, other: 4}
-      }
-
-      input = [
-        %{name: :a, other: 1},
-        %{name: :b, other: 4}
-      ]
-
-      actual = L.index_by(input, :name)
-
-      assert expected == actual
-    end
   end
 end

--- a/test/kitchen_sink/misc_test.exs
+++ b/test/kitchen_sink/misc_test.exs
@@ -4,10 +4,11 @@ defmodule KitchenSink.MiscTest do
   use ExUnit.Case
   import KitchenSink.Misc
 
+  doctest KitchenSink.Misc, import: true
+
   test "curried nth function is put into the module and works as expected" do
 
-
-    tuple = {1, 2 ,3 ,4 ,5}
+    tuple = {1, 2, 3, 4, 5}
     list = [1, 2, 3, 4, 5]
     map = %{a: 1, b: 2, c: 3, d: 4, e: 5}
 
@@ -23,7 +24,7 @@ defmodule KitchenSink.MiscTest do
 
   end
   test "named nth functions is put into the module and works as expected" do
-    tuple = {1, 2 ,3 ,4 ,5}
+    tuple = {1, 2, 3, 4, 5}
     list = [1, 2, 3, 4, 5]
     map = %{a: 1, b: 2, c: 3, d: 4, e: 5}
 


### PR DESCRIPTION
Move typical use examples into doctests and only leave the edge cases as unit tests.
Augment typespecs for the respective modules.

#69 was merged into the wrong branch. 