### PR TITLE
Add drop option to Struct.to_map()

### DIFF
--- a/lib/kitchen_sink/struct.ex
+++ b/lib/kitchen_sink/struct.ex
@@ -1,31 +1,35 @@
 defmodule KitchenSink.Struct do
   @moduledoc "functions that apply to structs"
 
-  defp do_deep_struct_to_map({key, value}, acc) when is_list value do
-    result = Enum.map(value, &do_deep_struct_to_map/1)
+  defp do_deep_resolve_struct_to_map({key, value}, acc, options) when is_list value do
+    result = Enum.map(value, &do_deep_struct_to_map(&1, options))
     Map.put(acc, key, result)
   end
-  defp do_deep_struct_to_map({key, value}, acc) when is_map value do
-    result = do_deep_struct_to_map(value)
+  defp do_deep_resolve_struct_to_map({key, value}, acc, options) when is_map value do
+    result =
+      value
+      |> Map.drop(Keyword.get(options, :drop, []))
+      |> do_deep_struct_to_map(options)
     Map.put(acc, key, result)
   end
-  defp do_deep_struct_to_map({key, value}, acc) do
+  defp do_deep_resolve_struct_to_map({key, value}, acc, _) do
     Map.put(acc, key, value)
   end
-  defp do_deep_struct_to_map(struct1) when is_map struct1 do
+  defp do_deep_struct_to_map(struct1, options) when is_map struct1 do
     if Map.has_key?(struct1, :__struct__) do
       Map.from_struct(struct1)
     else
       struct1
     end
-    |> Enum.reduce(%{}, &do_deep_struct_to_map/2)
+    |> Map.drop(Keyword.get(options, :drop, []))
+    |> Enum.reduce(%{}, &do_deep_resolve_struct_to_map(&1, &2, options))
   end
-  defp do_deep_struct_to_map(value) do
+  defp do_deep_struct_to_map(value, _) do
     value
   end
 
   @doc "convert a struct to a map removing all structness"
-  def to_map(struct1) do
-    do_deep_struct_to_map(struct1)
+  def to_map(struct1, options \\ []) do
+    do_deep_struct_to_map(struct1, options)
   end
 end

--- a/test/kitchen_sink/struct_test.exs
+++ b/test/kitchen_sink/struct_test.exs
@@ -42,5 +42,36 @@ defmodule KitchenSink.StructTest do
       }
       assert Struct.to_map(input) == expected
     end
+
+    test "struct with map with nested unwanted key drops key correctly" do
+      input = %TestStructNested{
+        field1: "Hello",
+        field2: %{
+          wanted: "whatever",
+          unwanted: "go away",
+          other: %{
+            something: "wee",
+            unwanted: "does not want",
+            yet_another: %{
+              cool: "beans",
+              unwanted: {:__junk__, 3, 5}
+            }
+          }
+        }
+      }
+      expected =  %{
+        field1: "Hello",
+        field2: %{
+          wanted: "whatever",
+          other: %{
+            something: "wee",
+            yet_another: %{
+              cool: "beans"
+            }
+          }
+        }
+      }
+      assert Struct.to_map(input, drop: [:unwanted]) == expected
+    end
   end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,2 +1,1 @@
-# IEx.break!(KitchenSink.Struct, :do_deep_struct_to_map, 3, 10)
 ExUnit.start()

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+# IEx.break!(KitchenSink.Struct, :do_deep_struct_to_map, 3, 10)
 ExUnit.start()


### PR DESCRIPTION
Adds ability to drop keys (like say, Ecto's often unwanted __meta__ keys) recursively from the struct in the conversion process.