### PR TITLE
Upgrade dialyzer

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 19.0
+elixir 1.3.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 19.0
-elixir 1.3.2
+elixir 1.4.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# KitchenSink 1.2.0 Release Notes (2017-08-22)
+# KitchenSink 1.3.0 Release Notes (2017-08-25)
+
+## Changes since 1.2.0
+  * Bump Elixir version to 1.4.5
+  * Update dialyxir - dev only
+  * Use asdf's .tool-versions to define versions of Erlang and Elixir
 
 ## Changes since 1.1.0
   * Added `Math.floor/2` delegated to `Math.round_down_to_multiple/2`

--- a/circle_pre_build.sh
+++ b/circle_pre_build.sh
@@ -8,14 +8,7 @@ fi
 # Add plugins for asdf
 asdf plugin-list | grep -q erlang || asdf plugin-add erlang https://github.com/asdf-vm/asdf-erlang.git
 asdf plugin-list | grep -q elixir || asdf plugin-add elixir https://github.com/asdf-vm/asdf-elixir.git
-# Extract vars from elixir_buildpack.config
-. elixir_buildpack.config
-# Write .tool-versions
-echo "erlang $erlang_version" >> .tool-versions
-echo "elixir $elixir_version" >> .tool-versions
-# Install erlang/elixir
-asdf install erlang $erlang_version
-asdf install elixir $elixir_version
+asdf install
 # Get dependencies
 yes | mix deps.get
 yes | mix local.rebar

--- a/dialyzer.ignore-warnings
+++ b/dialyzer.ignore-warnings
@@ -1,0 +1,1 @@
+:0: Unknown function 'Elixir.ExUnit.Assertions':assert/2

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,2 +1,0 @@
-erlang_version=19.0
-elixir_version=1.3.2

--- a/lib/kitchen_sink/map.ex
+++ b/lib/kitchen_sink/map.ex
@@ -297,7 +297,7 @@ defmodule KitchenSink.Map do
   key-value in the Map has been transformed. supplying `prune: true` prunes the map so only transformed values are
   output.
   """
-  @spec transform(Map.t, Map.t, Keyword.t) :: Map.t
+  @spec transform(map, map, Keyword.t) :: map
   def transform(map, transformation_map, [prune: true] = _opts) do
     transform_key_value = fn (map, key, transform_fun) ->
       Map.get(map, key) |> transform_fun.()
@@ -350,7 +350,7 @@ defmodule KitchenSink.Map do
   key-value in the Map has been transformed. supplying `prune: true` prunes the map so only transformed values are
   output.
   """
-  @spec transform(Map.t, Map.t) :: Map.t
+  @spec transform(map, map) :: map
   def transform(map, transformation_map) do
     keys_to_transform = Map.keys(transformation_map)
     map_without_transformed_keys = map |> Map.drop(keys_to_transform)

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule KitchenSink.Mixfile do
         extras: ["README.md", "CHANGELOG.md"],
       ],
       elixirc_paths: elixirc_paths(Mix.env),
-      dialyzer: [plt_add_deps: :transitive],
+      dialyzer: [ignore_warnings: "dialyzer.ignore-warnings", plt_add_deps: :transitive],
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule KitchenSink.Mixfile do
 
   @moduledoc false
 
-  @version "1.2.0"
+  @version "1.3.0"
   @repo_url "https://github.com/planswell/kitchen-sink"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule KitchenSink.Mixfile do
     [
       app: :kitchen_sink,
       version: @version,
-      elixir: "~> 1.3",
+      elixir: "~> 1.4",
       build_path: "_build",
       deps_path: "deps",
       lockfile: "mix.lock",

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,5 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], []},
   "credo": {:hex, :credo, "0.8.1", "137efcc99b4bc507c958ba9b5dff70149e971250813cbe7d4537ec7e36997402", [:mix], [{:bunt, "~> 0.2.0", [repo: "hexpm", hex: :bunt, optional: false]}], "hexpm"},
-  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], []},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], []},
   "ex_doc": {:hex, :ex_doc, "0.16.1", "b4b8a23602b4ce0e9a5a960a81260d1f7b29635b9652c67e95b0c2f7ccee5e81", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}


### PR DESCRIPTION
## Changes since 1.2.0
  * Bump Elixir version to 1.4.5
  * Update dialyxir to a more modern version - dev only
  * Use asdf's .tool-versions to define versions of Erlang and Elixir