### PR TITLE
Fix getting maps from structs

### DIFF
--- a/lib/kitchen_sink/struct.ex
+++ b/lib/kitchen_sink/struct.ex
@@ -17,7 +17,7 @@ defmodule KitchenSink.Struct do
   end
   defp do_deep_struct_to_map(struct1, options) when is_map struct1 do
     if Map.has_key?(struct1, :__struct__) do
-      Map.from_struct(struct1)
+      KitchenSink.Map.clean_struct(struct1)
     else
       struct1
     end

--- a/test/kitchen_sink/struct_test.exs
+++ b/test/kitchen_sink/struct_test.exs
@@ -6,8 +6,8 @@ defmodule KitchenSink.StructTest do
   alias KitchenSink.Struct
 
   describe "to_map()" do
-    test "empty struct converts to map with nil fields" do
-      assert Struct.to_map(%TestStruct{}) == %{age: nil, name: nil}
+    test "empty struct converts to map with no fields" do
+      assert Struct.to_map(%TestStruct{}) == %{}
     end
 
     test "nested struct converts to map" do
@@ -17,12 +17,8 @@ defmodule KitchenSink.StructTest do
       }
       expected = %{
         field1: %{
-          age: nil,
-          name: nil,
         },
         field2: %{
-          age: nil,
-          name: nil,
         }
       }
       assert Struct.to_map(input) == expected
@@ -35,8 +31,6 @@ defmodule KitchenSink.StructTest do
       }
       expected = %{
         field1: %{
-          age: nil,
-          name: nil
         },
         field2: ["something", "else"]
       }


### PR DESCRIPTION
If we ever use the map for any merging the default values in the
struct will ruin that. We only care about modified values.